### PR TITLE
feat: add cloudranger cli

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,15 +10,11 @@ on:
       - reopened
       - synchronize
 
-permissions:
-  contents: write
-  packages: write
-
 jobs:
   test:
     strategy:
       matrix:
-        go-version: ['1.20', '1.21', stable]
+        go-version: ['1.21', '1.22', stable]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
@@ -32,45 +28,3 @@ jobs:
       - run: make lint
       - run: make test
       - run: make bench
-
-  # only create a new tag/release on main builds:
-  release:
-    if: github.ref == 'refs/heads/main'
-    needs: [test]
-    runs-on: ubuntu-latest
-    steps:
-      - name: checkout code with full history (unshallow)
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-        with:
-          fetch-depth: 0
-          fetch-tags: true
-
-      # only generate a new release if certain files change:
-      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3
-        id: filter
-        with:
-          filters: |
-            app:
-              - '**.go'
-              - 'go.mod'
-              - 'go.sum'
-
-      - uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5
-        if: steps.filter.outputs.app == 'true'
-        with:
-          go-version-file: go.mod
-
-      - name: install autotag binary
-        if: steps.filter.outputs.app == 'true'
-        run: |
-          curl -sL https://git.io/autotag-install | sudo sh -s -- -b /usr/local/bin
-
-      - name: increment tag and create release
-        if: steps.filter.outputs.app == 'true'
-        run: |
-          set -eou pipefail
-
-          new_version=$(autotag -vn)
-          gh release create v"${new_version}" --target main --title "v${new_version}" --generate-notes
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,40 @@
+name: create release assets
+
+on:
+  push:
+    branches:
+      - main
+    # limit when we create a release by the files changed:
+    paths:
+      - go.mod
+      - go.sum
+      - '**.go'
+  workflow_dispatch:
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+      packages: write
+
+    steps:
+      - name: checkout code with full history (unshallow)
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: install autotag binary
+        run: |
+          curl -sL https://git.io/autotag-install | sh -s -- -b "${RUNNER_TEMP}/bin"
+
+      - name: increment tag and create release
+        run: |
+          set -eou pipefail
+
+          new_version=$(autotag -vn)
+          gh release create v"${new_version}" --target main --title "v${new_version}" --generate-notes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 Attic/
 HACK.md
+cloudranger

--- a/README.md
+++ b/README.md
@@ -32,6 +32,14 @@ func main() {
 }
 ```
 
+A small cli is included in [cmd/cloudranger](cmd/cloudranger). It is EXPERIMENTAL and its behavior, flags, and output is likely to change.
+
+```sh
+$ go run cmd/cloudranger/main.go 3.5.140.101
+
+{"cloud":"AWS","region":"ap-northeast-2"}
+```
+
 ## Testing and Benchmarks
 
 ```sh

--- a/cmd/cloudranger/main.go
+++ b/cmd/cloudranger/main.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/planetscale/cloudranger"
+)
+
+type out struct {
+	Cloud  string `json:"cloud"`
+	Region string `json:"region"`
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		usage()
+		os.Exit(1)
+	}
+
+	ranger := cloudranger.New()
+
+	ip := os.Args[1]
+
+	info, found := ranger.GetIP(ip)
+	if !found {
+		fmt.Fprintf(os.Stderr, "IP not in the database: %q\n", ip)
+		os.Exit(0)
+	}
+
+	o := out{
+		Cloud:  info.Cloud(),
+		Region: info.Region(),
+	}
+
+	if err := json.NewEncoder(os.Stdout).Encode(o); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func usage() {
+	fmt.Println("Usage: cloudranger <ip>")
+}


### PR DESCRIPTION
a quick cli because I needed to access the database via non-go apps/scripts

i may come back to it at a later time, with these possible changes in mind:
1. return non-zero if the IP is not in the database. right now it returns 0
2. add flags for additional output formats
3. when in json mode (default) output an error in json format. right now it outputs a regular string indicating not found. it is up to the caller to handle non-json responses as "ip not found"

I also split the github actions workflows into two:
1. `ci` - runs on all branches, lints + tests
2. `release` - runs on main branches when any go code has been updated and creates a new version tag