### PR TITLE
Update CI Go version matrix to 1.25, 1.26, and stable

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: ['1.21', '1.22', stable]
+        go-version: ['1.25', '1.26', stable]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Updates the GitHub Actions CI test matrix to run against current Go versions.

- Test Go `1.25`, `1.26`, and `stable`
- Drop Go `1.21` and `1.22`

No application code changes.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://planetscale.slack.com/archives/C04F55N5STW/p1788198975855949?thread_ts=1788198975.855949&cid=C04F55N5STW)

<div><a href="https://cursor.com/agents/bc-ca8a0da5-88d8-51e0-8ccb-c30b53dab8b1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ca8a0da5-88d8-51e0-8ccb-c30b53dab8b1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

